### PR TITLE
Convert Popup Tabs to a Dropdown Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ This script adds transparent padding, centers the image, and generates tiles. It
 
 Thanks to the separation between raw marker data and the runtime projection, you won’t need to adjust marker coordinates or apply runtime shifts when padding, shifting or scaling the map image, unless the source image itself changes. All coordinates are resolved at build time.
 
+## Statistics
+
+Since launch, the project has seen **2'010** unique visitors and **196'980** total requests, aggregated across all months. These statistics are provided by Cloudflare.
+
+<details>
+<summary>June 2025</summary>
+<br>
+
+Unique Visitors: **2'010** \
+Total Requests: **196'980**
+
+</details>
+
 ## Acknowledgements
 
 This project wouldn’t be possible without the tireless efforts of the following individuals – and of course, [Blue Scarab Entertainment](https://www.bluescarab.se/), the studio behind _Equinox: Homecoming_:

--- a/app/components/dropdown.module.css
+++ b/app/components/dropdown.module.css
@@ -1,0 +1,50 @@
+.dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.button {
+  display: flex;
+  background: var(--background-dark);
+  border: none;
+  color: var(--text-dark);
+  padding: var(--padding-6xs) var(--padding-xl);
+  cursor: pointer;
+  justify-content: center;
+  align-items: center;
+  gap: var(--gap-6xs);
+}
+
+.content {
+  position: absolute;
+  background: var(--accent-dark);
+  padding: none;
+  z-index: 1000;
+  overflow: hidden;
+  top: 100%;
+  left: 0;
+  animation: panelIn 150ms ease-out both;
+  transform-origin: top;
+  min-width: 100%;
+}
+
+@keyframes panelIn {
+  from {
+    opacity: 0;
+    transform: scaleY(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+.item {
+  color: var(--text-dark);
+  text-align: left;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--padding-6xs) var(--padding-xl);
+  white-space: nowrap;
+}

--- a/app/components/dropdown.tsx
+++ b/app/components/dropdown.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+import { CaretDown } from '@phosphor-icons/react';
+import styles from './dropdown.module.css';
+
+type Props = {
+  options: string[];
+  selected: string;
+  onSelect: (value: string) => void;
+};
+
+export default function Dropdown({ options, selected, onSelect }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return (
+    <div className={styles.dropdown} ref={ref}>
+      <button
+        className={styles.button}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {selected}
+        <CaretDown size="1em" />
+      </button>
+      {open && (
+        <div className={styles.content}>
+          {options
+            .filter((option) => option !== selected)
+            .map((option) => (
+              <button
+                key={option}
+                className={styles.item}
+                onClick={() => {
+                  onSelect(option);
+                  setOpen(false);
+                }}
+              >
+                {option}
+              </button>
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/components/map/popup.module.css
+++ b/app/components/map/popup.module.css
@@ -3,33 +3,7 @@
   width: 15rem;
   flex-direction: column;
   justify-content: center;
-  align-items: center;
-}
-
-.tabs {
-  display: flex;
-  align-items: center;
-  align-self: stretch;
-}
-
-.tab {
-  display: flex;
-  padding: 0.3125rem;
-  justify-content: center;
-  align-items: center;
-  background: none;
-  border: none;
-  cursor: pointer;
-  transition: color 0.2s ease;
-  color: var(--text-dark);
-  border-radius: 0;
-  background: var(--accent-dark);
-  overflow-x: hidden;
-  white-space: nowrap;
-}
-
-.tab.active {
-  background: var(--background-dark);
+  align-items: start;
 }
 
 .content {

--- a/app/components/map/popup.tsx
+++ b/app/components/map/popup.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import styles from './popup.module.css';
 import { TCategoryPayloads } from '@/types/popup';
 import { TBookmarkId } from '@/types/bookmark';
+import Dropdown from '../dropdown';
 
 type Props = {
   id: string;
@@ -36,17 +37,11 @@ export default function Popup({
   return (
     <div className={styles.popup}>
       {categoryKeys.length > 1 && (
-        <div className={styles.tabs}>
-          {categoryKeys.map((cat) => (
-            <button
-              key={cat}
-              onClick={() => setActiveCategory(cat)}
-              className={`${styles.tab} ${cat === activeCategory ? styles.active : ''}`}
-            >
-              {cat}
-            </button>
-          ))}
-        </div>
+        <Dropdown
+          options={categoryKeys}
+          selected={activeCategory}
+          onSelect={setActiveCategory}
+        />
       )}
 
       <div className={styles.content}>


### PR DESCRIPTION
The tabs inside the popups have been converted to a dropdown menu because the layout breaks if too many categories are added.