### PR TITLE
Load Icons from Cloudflare R2

### DIFF
--- a/app/hooks/use-map-libre-map-layer-register.tsx
+++ b/app/hooks/use-map-libre-map-layer-register.tsx
@@ -30,7 +30,7 @@ export function useMapLibreMapLayerRegister() {
                     if (!mapInstance.hasImage(icon)) {
                         const img = await loadIcon(
                             mapInstance,
-                            `/icon/64/${icon}.webp`
+                            `https://cdn.equinoxmap.app/icon/64/${icon}.webp`
                         );
                         mapInstance.addImage(icon, img);
                     }


### PR DESCRIPTION
Currently, icons are loaded as static content served from `/public`. However, this generates a lot of request to the vercel edge network. Therefore, icons have been uploaded to an R2 bucket and served from there instead.